### PR TITLE
scipy: fix library directories

### DIFF
--- a/recipes-devtools/python/python3-scipy_1.5.4.bb
+++ b/recipes-devtools/python/python3-scipy_1.5.4.bb
@@ -30,7 +30,7 @@ export F90 = "${TARGET_PREFIX}gfortran"
 export F77 = "${TARGET_PREFIX}gfortran"
 export FARCH = "${TUNE_CCARGS}"
 
-export NUMPY_INCLUDE_PATH = "${STAGING_DIR_TARGET}/usr/lib/python${PYTHON_BASEVERSION}/site-packages/numpy/core/include"
+export NUMPY_INCLUDE_PATH = "${STAGING_DIR_TARGET}${libdir}/python${PYTHON_BASEVERSION}/site-packages/numpy/core/include"
 
 # Numpy expects the LDSHARED env variable to point to a single
 # executable, but OE sets it to include some flags as well. So we split


### PR DESCRIPTION
Using the standard library directory variable instead of a hardcoded path improves compatibility with different types of systems. For example, it fixes compatibility with systems that need multilib support for coexisting 32bit and 64bit libraries.